### PR TITLE
test(auth): adiciona testes de usuario duplicado, senha limite e navegacao (25 testes)

### DIFF
--- a/client/cypress/e2e/features/cadastro.feature
+++ b/client/cypress/e2e/features/cadastro.feature
@@ -54,3 +54,13 @@ Feature: Cadastro de Usuários - Interface
     And preencho a senha com "Segura@123"
     And clico no botão de cadastro
     Then vejo a mensagem de erro "Nome de usuário deve ter no mínimo 3 caracteres"
+
+  Scenario: Navegação da tela de cadastro para login
+    Given estou na tela de cadastro
+    When clico no link "Entrar"
+    Then sou redirecionado para a tela de boas-vindas
+
+  Scenario: Navegação da tela de login para cadastro
+    Given estou na tela de login
+    When clico no link "Criar conta"
+    Then sou redirecionado para a tela de cadastro

--- a/client/cypress/e2e/step_definitions/cadastro.js
+++ b/client/cypress/e2e/step_definitions/cadastro.js
@@ -18,7 +18,7 @@ Given('já existe um usuário com e-mail {string}', (email) => {
     url: 'http://localhost:8000/auth/register',
     body: {
       email: email,
-      nome_usuario: 'usuario_existente',
+      usuario: 'usuario_existente',
       telefone: '(88) 98888-8888',
       senha: 'Segura@123',
     },
@@ -31,7 +31,7 @@ When('preencho o telefone com {string}', (telefone) => {
 })
 
 When('preencho o nome de usuário com {string}', (nome) => {
-  cy.get('[data-cy="input-nome-usuario"]').clear().type(nome)
+  cy.get('[data-cy="input-usuario"]').clear().type(nome)
 })
 
 When('clico no botão de cadastro', () => {
@@ -41,4 +41,17 @@ When('clico no botão de cadastro', () => {
 Then('sou redirecionado para a tela de sucesso', () => {
   cy.url().should('include', '/cadastro-sucesso')
   cy.get('[data-cy="msg-sucesso"]').should('be.visible')
+})
+
+When('clico no link {string}', (texto) => {
+  cy.contains(texto).click()
+})
+
+Then('sou redirecionado para a tela de boas-vindas', () => {
+  cy.url().should('include', '/')
+  cy.url().should('not.include', '/cadastro')
+})
+
+Then('sou redirecionado para a tela de cadastro', () => {
+  cy.url().should('include', '/cadastro')
 })

--- a/client/cypress/e2e/step_definitions/login.js
+++ b/client/cypress/e2e/step_definitions/login.js
@@ -18,7 +18,7 @@ Given('o usuário {string} está cadastrado com senha {string}', (email, senha) 
     url: 'http://localhost:8000/auth/register',
     body: {
       email: email,
-      nome_usuario: email.split('@')[0],
+      usuario: email.split('@')[0],
       telefone: '(88) 98888-8888',
       senha: senha,
     },

--- a/client/src/components/FormCard.jsx
+++ b/client/src/components/FormCard.jsx
@@ -1,0 +1,15 @@
+/**
+ * FormCard — componente reutilizável para os formulários de autenticação.
+ * Encapsula o layout do card branco centralizado, evitando duplicação
+ * entre as telas de Login e Cadastro (princípio DRY).
+ */
+export default function FormCard({ titulo, children }) {
+  return (
+    <div className="bg-white rounded-3xl p-8 w-full max-w-sm shadow-xl">
+      <h2 className="text-center text-2xl font-bold text-[#06065D] mb-6">
+        {titulo}
+      </h2>
+      {children}
+    </div>
+  )
+}

--- a/client/src/pages/Cadastro.jsx
+++ b/client/src/pages/Cadastro.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { cadastrar } from '../services/api'
+import FormCard from '../components/FormCard'
 
 export default function Cadastro() {
   const navigate = useNavigate()
@@ -74,9 +75,7 @@ export default function Cadastro() {
 
   return (
     <div className="min-h-screen bg-[#06065D] flex items-center justify-center p-6">
-      <div className="bg-white rounded-3xl p-8 w-full max-w-sm shadow-xl">
-        <h2 className="text-center text-2xl font-bold text-[#06065D] mb-6">Cadastro</h2>
-
+      <FormCard titulo="Cadastro">
         <input
           data-cy="input-email"
           name="email"
@@ -135,7 +134,7 @@ export default function Cadastro() {
             Entrar
           </button>
         </p>
-      </div>
+      </FormCard>
     </div>
   )
 }

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { login } from '../services/api'
+import FormCard from '../components/FormCard'
 
 export default function Login({ embedded = false }) {
   const navigate = useNavigate()
@@ -34,9 +35,7 @@ export default function Login({ embedded = false }) {
   }
 
   const card = (
-    <div className="bg-white rounded-3xl p-8 w-full max-w-sm shadow-xl">
-      <h2 className="text-center text-2xl font-bold text-[#06065D] mb-6">Login</h2>
-
+    <FormCard titulo="Login">
       <input
         data-cy="input-email"
         name="email"
@@ -74,7 +73,7 @@ export default function Login({ embedded = false }) {
           Criar conta
         </button>
       </p>
-    </div>
+    </FormCard>
   )
 
   if (embedded) return card

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,4 +1,4 @@
-const API_URL = 'http://localhost:8000'
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
 export async function cadastrar(dados) {
   const response = await fetch(`${API_URL}/auth/register`, {

--- a/features/registration_access.feature
+++ b/features/registration_access.feature
@@ -36,3 +36,22 @@ Feature: Cadastro de Usuários
     And insiro senha "abc"
     And clico no botão "Cadastre-se"
     Then o sistema rejeita o cadastro com erro de validação
+
+    Scenario: Cadastro com nome de usuário já existente
+    Given estou na tela de cadastro
+    And o sistema já possui usuário com e-mail "existente@email.com", nome "UsuarioExistente" e senha "Senha@123"
+    When eu insiro e-mail "novo@email.com"
+    And eu insiro nome de usuário "UsuarioExistente"
+    And eu insiro senha "Segura@123"
+    And eu clico no botão "Cadastre-se"
+    Then o sistema exibe mensagem de alerta "Nome de usuário já cadastrado"
+
+  Scenario: Cadastro com senha de exatamente 6 caracteres
+    Given estou na tela de cadastro
+    And o sistema não possui usuário com e-mail "joao@email.com"
+    When insiro e-mail "joao@email.com"
+    And insiro telefone "(88) 988888888"
+    And insiro nome de usuário "joaosilva"
+    And insiro senha "Seis12"
+    And clico no botão "Cadastre-se"
+    Then o sistema exibe mensagem "Cadastro realizado com sucesso"

--- a/server/app/repositories/user_repository.py
+++ b/server/app/repositories/user_repository.py
@@ -4,21 +4,29 @@ from app.models.user import UserModel
 
 class UserRepository:
     """
-    Única camada que fala diretamente com o banco de dados.
-    Nenhuma outra camada acessa o banco fora daqui.
+    Repositório de usuários — única camada responsável pelo acesso ao banco.
+    Segue o princípio da Responsabilidade Única (SRP) e o padrão Repository,
+    isolando a lógica de persistência do restante da aplicação.
     """
 
     def __init__(self, db: Session):
-        self.db = db
+        self._db = db
 
     def find_by_email(self, email: str) -> UserModel | None:
         """Busca uma pessoa pelo e-mail. Retorna None se não existir."""
-        return self.db.query(UserModel).filter(UserModel.email == email).first()
+        return (
+            self._db.query(UserModel)
+            .filter(UserModel.email == email)
+            .first()
+        )
 
     def find_by_usuario(self, usuario: str) -> UserModel | None:
-        return self.db.query(UserModel).filter(
-            UserModel.usuario == usuario
-        ).first()
+        """Busca uma pessoa pelo nome de usuário (PK). Retorna None se não existir."""
+        return (
+            self._db.query(UserModel)
+            .filter(UserModel.usuario == usuario)
+            .first()
+        )
 
     def create(
         self,
@@ -27,7 +35,9 @@ class UserRepository:
         telefone: str,
         senha: str,
     ) -> UserModel:
-        """Cria e persiste uma nova pessoa no banco.
+        """
+        Cria e persiste uma nova pessoa no banco.
+        Recebe a senha JÁ hasheada — responsabilidade do Service.
         'nome' é preenchido automaticamente com o valor de 'usuario'.
         """
         pessoa = UserModel(
@@ -37,7 +47,7 @@ class UserRepository:
             senha=senha,
             nome=usuario,
         )
-        self.db.add(pessoa)
-        self.db.commit()
-        self.db.refresh(pessoa)
+        self._db.add(pessoa)
+        self._db.commit()
+        self._db.refresh(pessoa)
         return pessoa

--- a/server/app/routers/auth_router.py
+++ b/server/app/routers/auth_router.py
@@ -4,8 +4,6 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.schemas.user import TokenResponse, UserLoginRequest, UserRegisterRequest
 from app.services.auth_service import AuthService
-from app.models.user import UserModel
-import os
 
 router = APIRouter(
     prefix="/auth",
@@ -13,21 +11,59 @@ router = APIRouter(
 )
 
 
-@router.post("/register", status_code=status.HTTP_201_CREATED)
-def cadastrar(data: UserRegisterRequest, db: Session = Depends(get_db)):
+@router.post(
+    "/register",
+    status_code=status.HTTP_201_CREATED,
+    summary="Cadastro de novo usuário",
+    response_description="Usuário cadastrado com sucesso",
+)
+def cadastrar(
+    data: UserRegisterRequest,
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    Cadastra um novo usuário no sistema.
+
+    - **usuario**: nome de usuário único
+    - **email**: e-mail único e válido
+    - **telefone**: telefone no formato (XX) XXXXX-XXXX
+    - **senha**: mínimo 6 caracteres
+    """
     service = AuthService(db)
     return service.cadastrar(data)
 
 
-@router.post("/login", response_model=TokenResponse, status_code=status.HTTP_200_OK)
-def login(data: UserLoginRequest, db: Session = Depends(get_db)):
+@router.post(
+    "/login",
+    status_code=status.HTTP_200_OK,
+    response_model=TokenResponse,
+    summary="Login de usuário",
+    response_description="Token JWT gerado com sucesso",
+)
+def login(
+    data: UserLoginRequest,
+    db: Session = Depends(get_db),
+) -> TokenResponse:
+    """
+    Autentica um usuário e retorna um token JWT.
+
+    - **email**: e-mail cadastrado
+    - **senha**: senha do usuário
+    """
     service = AuthService(db)
     return service.login(data)
 
 
-@router.delete("/test/cleanup", status_code=status.HTTP_200_OK)
-def cleanup(db: Session = Depends(get_db)):
-    """Endpoint exclusivo para testes — limpa todos os usuários do banco."""
+@router.delete(
+    "/test/cleanup",
+    status_code=status.HTTP_200_OK,
+    summary="Limpa banco de dados de teste",
+    include_in_schema=False,
+)
+def cleanup(db: Session = Depends(get_db)) -> dict:
+    """Endpoint exclusivo para testes — remove todos os usuários do banco."""
+    from app.models.user import UserModel
+    import os
     if os.getenv("ENVIRONMENT") != "production":
         db.query(UserModel).delete()
         db.commit()

--- a/server/app/schemas/user.py
+++ b/server/app/schemas/user.py
@@ -2,7 +2,11 @@ from pydantic import BaseModel, EmailStr, field_validator
 
 
 class UserRegisterRequest(BaseModel):
-    """Dados esperados no corpo da requisição de cadastro."""
+    """
+    Dados esperados no corpo da requisição de cadastro.
+    Apenas os campos mínimos obrigatórios são exigidos.
+    Campos opcionais de perfil (nome, sobrenome, etc.) são preenchidos depois.
+    """
     usuario: str
     email: EmailStr
     telefone: str
@@ -15,6 +19,14 @@ class UserRegisterRequest(BaseModel):
         if len(value) < 6:
             raise ValueError("A senha deve ter no mínimo 6 caracteres")
         return value
+
+    @field_validator("usuario")
+    @classmethod
+    def usuario_minimo(cls, value: str) -> str:
+        """Regra de negócio: nome de usuário deve ter no mínimo 3 caracteres."""
+        if len(value.strip()) < 3:
+            raise ValueError("Nome de usuário deve ter no mínimo 3 caracteres")
+        return value.strip()
 
 
 class UserLoginRequest(BaseModel):

--- a/server/app/services/auth_service.py
+++ b/server/app/services/auth_service.py
@@ -21,17 +21,56 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 class AuthService:
+    """
+    Serviço de autenticação — contém toda a lógica de negócio
+    de cadastro e login. Segue o princípio da Responsabilidade Única (SRP).
+    """
 
     def __init__(self, db: Session):
         self.repo = UserRepository(db)
 
+    # ── Métodos privados (Single Responsibility) ───────────────────────────
+
+    def _hash_senha(self, senha: str) -> str:
+        """Gera o hash bcrypt de uma senha pura."""
+        return pwd_context.hash(senha)
+
+    def _verificar_senha(self, senha_pura: str, senha_hash: str) -> bool:
+        """Verifica se a senha pura corresponde ao hash armazenado."""
+        return pwd_context.verify(senha_pura, senha_hash)
+
+    def _gerar_token(self, usuario: str, email: str) -> str:
+        """
+        Gera um token JWT assinado com expiração configurável.
+        Responsabilidade isolada — facilita testes e futuras trocas de algoritmo.
+        """
+        expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        payload = {
+            "sub": usuario,
+            "email": email,
+            "exp": expire,
+        }
+        return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+    def _lancar_credenciais_invalidas(self) -> None:
+        """
+        Lança exceção 401 com mensagem genérica.
+        Mensagem intencional — não revela se foi e-mail ou senha que errou.
+        """
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Credenciais inválidas",
+        )
+
+    # ── Métodos públicos ───────────────────────────────────────────────────
+
     def cadastrar(self, data: UserRegisterRequest) -> dict:
         """
         Fluxo de cadastro:
-        1. Verifica se e-mail já existe → 409 se existir
-        2. Verifica se usuario já existe → 409 se existir
-        3. Gera o hash da senha (nunca salva a senha pura)
-        4. Persiste a pessoa no banco
+        1. Verifica duplicidade de e-mail → 409 se existir
+        2. Verifica duplicidade de usuario → 409 se existir
+        3. Gera hash da senha (nunca salva a senha pura)
+        4. Persiste no banco
         5. Retorna mensagem de sucesso
         """
         if self.repo.find_by_email(data.email):
@@ -46,45 +85,35 @@ class AuthService:
                 detail="Nome de usuário já cadastrado",
             )
 
-        senha_hasheada = pwd_context.hash(data.senha)
-
         self.repo.create(
             usuario=data.usuario,
             email=data.email,
             telefone=data.telefone,
-            senha=senha_hasheada,
+            senha=self._hash_senha(data.senha),
         )
 
         return {"message": "Cadastro realizado com sucesso"}
 
     def login(self, data: UserLoginRequest) -> TokenResponse:
+        """
+        Fluxo de login:
+        1. Busca pessoa pelo e-mail
+        2. Verifica senha contra hash
+        3. Gera token JWT com expiração
+        4. Retorna token + contatos + mensagem de boas-vindas
+        """
         pessoa = self.repo.find_by_email(data.email)
 
-        credenciais_invalidas = HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Credenciais inválidas",
-        )
-
         if not pessoa:
-            raise credenciais_invalidas
+            self._lancar_credenciais_invalidas()
 
-        if not pwd_context.verify(data.senha, pessoa.senha):
-            raise credenciais_invalidas
-
-        expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-        payload = {
-            "sub": pessoa.usuario,
-            "email": pessoa.email,
-            "exp": expire,
-        }
-        access_token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
-
-        contatos = user_contacts.get(pessoa.email, [])
+        if not self._verificar_senha(data.senha, pessoa.senha):
+            self._lancar_credenciais_invalidas()
 
         return TokenResponse(
-            access_token=access_token,
+            access_token=self._gerar_token(pessoa.usuario, pessoa.email),
             token_type="bearer",
             expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
             welcome_message=f"Bem-vindo, {pessoa.email}",
-            contacts=contatos,
+            contacts=user_contacts.get(pessoa.email, []),
         )

--- a/server/tests/step_definitions/test_cadastro.py
+++ b/server/tests/step_definitions/test_cadastro.py
@@ -154,3 +154,12 @@ def sistema_mantem_usuario_inalterado(client, context, nome_usuario, email):
 @then('o sistema rejeita o cadastro com erro de validação')
 def sistema_rejeita_senha_curta(context):
     assert context['response'].status_code == 422
+
+@scenario('registration_access.feature', 'Cadastro com nome de usuário já existente')
+def test_cadastro_usuario_duplicado():
+    pass
+
+
+@scenario('registration_access.feature', 'Cadastro com senha de exatamente 6 caracteres')
+def test_cadastro_senha_limite_exato():
+    pass

--- a/server/tests/test_unitario.py
+++ b/server/tests/test_unitario.py
@@ -11,7 +11,7 @@ def test_senha_muito_curta_deve_falhar():
     """Senha com menos de 6 caracteres deve lançar ValidationError."""
     with pytest.raises(ValidationError):
         UserRegisterRequest(
-            nome_usuario="joao",
+            usuario="joao",
             email="joao@email.com",
             telefone="(88) 98888-8888",
             senha="abc"
@@ -21,7 +21,7 @@ def test_senha_muito_curta_deve_falhar():
 def test_senha_valida_deve_passar():
     """Senha com 6 ou mais caracteres deve ser aceita."""
     user = UserRegisterRequest(
-        nome_usuario="joao",
+        usuario="joao",
         email="joao@email.com",
         telefone="(88) 98888-8888",
         senha="Segura@123"
@@ -33,7 +33,7 @@ def test_email_invalido_deve_falhar():
     """E-mail sem formato válido deve lançar ValidationError."""
     with pytest.raises(ValidationError):
         UserRegisterRequest(
-            nome_usuario="joao",
+            usuario="joao",
             email="emailinvalido",
             telefone="(88) 98888-8888",
             senha="Segura@123"
@@ -43,7 +43,7 @@ def test_email_invalido_deve_falhar():
 def test_email_valido_deve_passar():
     """E-mail com formato correto deve ser aceito."""
     user = UserRegisterRequest(
-        nome_usuario="joao",
+        usuario="joao",
         email="joao@email.com",
         telefone="(88) 98888-8888",
         senha="Segura@123"
@@ -57,5 +57,15 @@ def test_campos_obrigatorios_ausentes_devem_falhar():
         UserRegisterRequest(
             email="joao@email.com",
             senha="Segura@123"
-            # nome_usuario e telefone ausentes
         )
+
+
+def test_senha_com_exatamente_6_caracteres_deve_passar():
+    """Senha com exatamente 6 caracteres deve ser aceita — testa o limite exato da regra."""
+    user = UserRegisterRequest(
+        usuario="joao",
+        email="joao@email.com",
+        telefone="(88) 98888-8888",
+        senha="Seis12"
+    )
+    assert len(user.senha) == 6


### PR DESCRIPTION
## Descrição
Adição de novos testes e refatoração da feature de autenticação aplicando princípios de Clean Code e SOLID.

## Testes adicionados

### Serviço BDD (pytest-bdd)
- Cadastro com nome de usuário duplicado → retorna 409
- Cadastro com senha de exatamente 6 caracteres → retorna 201

### Unitários (pytest)
- Senha com exatamente 6 caracteres deve ser aceita — testa o limite exato

### GUI E2E (Cypress)
- Navegação da tela de cadastro para login
- Navegação da tela de login para cadastro

## Refatorações

### AuthService
- Extrai `_hash_senha()`, `_verificar_senha()` e `_gerar_token()` como métodos privados
- Extrai `_lancar_credenciais_invalidas()` eliminando duplicação de código
- Aplica SRP — cada método tem uma única responsabilidade

### UserRepository
- Renomeia `db` para `_db` indicando encapsulamento
- Melhora formatação das queries
- Adiciona docstrings em todos os métodos

### Frontend (api.js)
- Extrai URL base para variável de ambiente `VITE_API_URL`
- Elimina hardcode da URL

## Cobertura Total de Testes

| Tipo | Qtd | Framework |
|---|---|---|
| Serviço BDD | 8 | pytest-bdd |
| Unitários | 6 | pytest |
| GUI E2E | 11 | Cypress + Cucumber |
| **Total** | **25** | |

## Autora
Karoline — Backend + Frontend | Autenticação