### PR TITLE
Feat: Busca de conversas e usuários (GET /conversas/buscar)

### DIFF
--- a/features/lista_conversas.feature
+++ b/features/lista_conversas.feature
@@ -1,0 +1,54 @@
+# language: pt
+Funcionalidade: Lista de Conversas e Busca
+  Como um usuário autenticado do aplicativo de mensagens
+  Quero buscar minhas conversas e encontrar outros usuários pelo nome
+  Para abrir conversas existentes ou iniciar novas
+
+  Contexto:
+    Dado que o usuário é identificado pelo token JWT (Authorization: Bearer)
+    E a busca é por prefixo e ignora maiúsculas/minúsculas
+    E cada conversa pode ser de uma pessoa ("usuario") ou de um grupo ("grupo")
+
+  Cenário: Acesso sem autenticação é negado
+    Dado um cliente sem token JWT
+    Quando ele chama a busca de conversas
+    Então o sistema responde 401 Não Autorizado
+    # Garante que ninguém acesse as conversas de outro usuário (IDOR)
+
+  Cenário: Busca vazia lista as conversas existentes, mais recentes primeiro
+    Dado que "paulo" conversou com "joao" e, depois, com "paula"
+    Quando "paulo" busca com o termo vazio
+    Então as duas conversas são retornadas com status verdadeiro
+    E a conversa com "paula" (mais recente) aparece antes da conversa com "joao"
+    E cada conversa traz a última mensagem com o remetente e o texto
+
+  Cenário: Busca por prefixo ignorando maiúsculas e minúsculas
+    Dado que existem os usuários "paula" e "joao"
+    Quando "paulo" busca pelo termo "PA"
+    Então "paula" é retornada
+    E "joao" não é retornado
+    E o próprio "paulo" nunca aparece no resultado
+
+  Cenário: Usuário sem conversa iniciada aparece como conversa vazia
+    Dado que existe "carla", com quem "paulo" nunca conversou
+    Quando "paulo" busca pelo termo "ca"
+    Então "carla" é retornada com status falso
+    E sem última mensagem
+
+  Cenário: Conversas existentes têm prioridade sobre usuários novos
+    Dado que "paulo" já conversou com "paula", mas nunca com "pamela"
+    Quando "paulo" busca pelo termo "pa"
+    Então "paula" (status verdadeiro) aparece antes de "pamela" (status falso)
+
+  Cenário: Um usuário não enxerga as conversas de outro
+    Dado que "paulo" e "paula" trocaram mensagens
+    E que "joao" não possui nenhuma conversa
+    Quando "joao" autenticado busca com o termo vazio
+    Então ele recebe uma lista vazia
+    # Não vê a conversa entre "paulo" e "paula" (proteção contra IDOR)
+
+  Cenário: Grupos dos quais o usuário participa entram na lista
+    Dado que "paulo" participa do grupo "Paladinos"
+    Quando ele busca com o termo vazio
+    Então o grupo "Paladinos" é retornado com tipo "grupo" e status verdadeiro
+    E sem última mensagem, pois o envio de mensagens em grupo ainda não foi implementado

--- a/server/app/core/security.py
+++ b/server/app/core/security.py
@@ -1,0 +1,63 @@
+"""
+Verificação de token JWT para rotas protegidas.
+
+O login (auth_service) já *gera* o token com `jwt.encode`, colocando o nome de
+usuário no campo `sub`. Este módulo faz o caminho inverso: *valida* o token que
+chega no header `Authorization: Bearer <token>` e devolve o usuário autenticado.
+
+Reutiliza as MESMAS configurações do auth_service (SECRET_KEY e algoritmo), lidas
+do ambiente — caso contrário a assinatura não bateria e nenhum token validaria.
+"""
+import os
+
+from dotenv import load_dotenv
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+
+load_dotenv()
+
+SECRET_KEY = os.getenv("SECRET_KEY", "chave-padrao-insegura-mude-no-env")
+ALGORITHM = "HS256"
+
+# auto_error=False: nós mesmos lançamos o 401 quando o header faltar,
+# garantindo uma resposta de erro consistente.
+_esquema_bearer = HTTPBearer(auto_error=False)
+
+
+def get_usuario_atual(
+    credenciais: HTTPAuthorizationCredentials | None = Depends(_esquema_bearer),
+) -> str:
+    """
+    Dependência do FastAPI que identifica o usuário a partir do JWT.
+
+    - Lê o token do header `Authorization: Bearer <token>`.
+    - Valida assinatura e expiração.
+    - Retorna o `sub` (nome de usuário) embutido no token.
+
+    Qualquer falha (header ausente, token inválido, expirado ou sem `sub`)
+    resulta em 401 — impedindo que um usuário acesse conversas de outro (IDOR).
+    """
+    erro_401 = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Token de autenticação ausente ou inválido",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    if credenciais is None or not credenciais.credentials:
+        raise erro_401
+
+    try:
+        payload = jwt.decode(
+            credenciais.credentials,
+            SECRET_KEY,
+            algorithms=[ALGORITHM],
+        )
+    except JWTError:
+        raise erro_401
+
+    usuario = payload.get("sub")
+    if not usuario:
+        raise erro_401
+
+    return usuario

--- a/server/app/routers/conversas_router.py
+++ b/server/app/routers/conversas_router.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.security import get_usuario_atual
+from app.database import get_db
+from app.services.conversas_service import ConversasService
+
+router = APIRouter(
+    prefix="/conversas",
+    tags=["Conversas"],
+)
+
+
+@router.get(
+    "/buscar",
+    summary="Buscar conversas do usuário autenticado",
+    response_description="Lista de conversas (existentes primeiro) e usuários encontrados",
+)
+def buscar_conversas(
+    q: str = Query(
+        default="",
+        max_length=100,
+        description="Termo de busca por prefixo (nome de usuário ou nome de grupo). "
+        "Case-insensitive. Vazio retorna todas as conversas existentes.",
+    ),
+    usuario_atual: str = Depends(get_usuario_atual),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """
+    Busca as conversas do usuário autenticado.
+
+    O usuário é identificado pelo **JWT** (header `Authorization: Bearer <token>`),
+    nunca por parâmetro — garantindo que ninguém acesse as conversas de outro.
+
+    Regras:
+    - Busca por **prefixo**, case-insensitive (ex.: `Pa` → `paulo`, `paula`).
+    - `q` vazio → todas as conversas existentes, mais recentes primeiro.
+    - Conversas já existentes (`status: true`) vêm antes dos usuários ainda sem
+      conversa (`status: false`).
+    - Grupos retornados são apenas aqueles dos quais o usuário participa.
+
+    Cada item:
+    ```
+    {
+      "tipo": "usuario" | "grupo",
+      "id": "<usuario>" | <id_grupo>,
+      "nome": "<nome>",
+      "status": true | false,
+      "last_message": {"remetente": "<usuario>", "texto": "<texto>"} | null
+    }
+    ```
+    """
+    service = ConversasService(db)
+    return service.buscar(usuario_atual, q)

--- a/server/app/services/conversas_service.py
+++ b/server/app/services/conversas_service.py
@@ -1,0 +1,249 @@
+"""
+Serviço de busca de conversas.
+
+Não existe tabela 'conversa' no banco — o conceito é *derivado*:
+
+- Conversas 1:1  → das tabelas 'mensagem' (remetente) + 'recebe' (destinatário),
+                   considerando apenas mensagens sem grupo (id_grupo nulo).
+- Conversas de grupo → da tabela 'esta_em' (grupos que eu participo) + 'grupo'.
+
+A busca é por PREFIXO e case-insensitive: "Pa" casa com "paulo", "paula", etc.
+Retorna primeiro as conversas que já existem (ordenadas pela mais recente) e,
+em seguida, os usuários encontrados com quem ainda não há conversa (status=False).
+
+Segue o princípio da Responsabilidade Única (SRP): isola a regra de negócio da
+camada de rota.
+"""
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.models.esta_em import EstaModel
+from app.models.grupo import GrupoModel
+from app.models.mensagem import MensagemModel
+from app.models.recebe import RecebeModel
+from app.models.user import UserModel
+
+
+class ConversasService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    # ── Auxiliares ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _escapar_like(termo: str) -> str:
+        """
+        Neutraliza os curingas do LIKE ('%' e '_') para que o input seja tratado
+        como texto literal. A proteção contra SQL Injection em si vem da
+        parametrização do SQLAlchemy (bind parameters) — aspas e ';' já não têm
+        efeito; aqui tratamos apenas os curingas do padrão de busca.
+        """
+        return (
+            termo.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+
+    # ── Caso de uso principal ──────────────────────────────────────────────
+
+    def buscar(self, usuario_atual: str, q: str = "") -> list[dict]:
+        """
+        Busca as conversas do usuário autenticado.
+
+        Args:
+            usuario_atual: nome de usuário extraído do JWT (nunca da URL).
+            q: termo de busca (prefixo, case-insensitive). Vazio → todas as
+               conversas existentes.
+
+        Returns:
+            Lista de itens no formato:
+            {
+                "tipo": "usuario" | "grupo",
+                "id": <usuario:str | id_grupo:int>,
+                "nome": <str>,
+                "status": <bool>,           # True se a conversa já existe
+                "last_message": {"remetente": str, "texto": str} | None
+            }
+        """
+        prefixo = (q or "").strip().lower()
+
+        existentes = self._conversas_existentes(usuario_atual, prefixo)
+
+        # Ordena as existentes pela mensagem mais recente (id_mensagem maior).
+        # Conversas sem mensagem (ex.: grupo recém-criado) vão para o fim do bloco.
+        existentes.sort(key=lambda e: e["ordem"], reverse=True)
+        resultado = [e["item"] for e in existentes]
+
+        # Usuários ainda sem conversa só entram quando há termo de busca.
+        if prefixo:
+            ja_listados = {
+                e["item"]["id"]
+                for e in existentes
+                if e["item"]["tipo"] == "usuario"
+            }
+            resultado.extend(
+                self._usuarios_sem_conversa(usuario_atual, q.strip(), ja_listados)
+            )
+
+        return resultado
+
+    # ── Conversas já existentes (1:1 + grupos) ─────────────────────────────
+
+    def _conversas_existentes(self, usuario_atual: str, prefixo: str) -> list[dict]:
+        itens: list[dict] = []
+        itens.extend(self._conversas_1a1(usuario_atual, prefixo))
+        itens.extend(self._conversas_de_grupo(usuario_atual, prefixo))
+        return itens
+
+    def _conversas_1a1(self, usuario_atual: str, prefixo: str) -> list[dict]:
+        # Todas as mensagens 1:1 que me envolvem (como remetente OU destinatário),
+        # da mais nova para a mais antiga.
+        linhas = (
+            self.db.query(
+                MensagemModel.id_mensagem.label("id_mensagem"),
+                MensagemModel.usuario.label("remetente"),
+                MensagemModel.texto.label("texto"),
+                RecebeModel.usuario.label("destinatario"),
+            )
+            .join(RecebeModel, MensagemModel.id_mensagem == RecebeModel.id_mensagem)
+            .filter(MensagemModel.id_grupo.is_(None))
+            .filter(
+                or_(
+                    MensagemModel.usuario == usuario_atual,
+                    RecebeModel.usuario == usuario_atual,
+                )
+            )
+            .order_by(MensagemModel.id_mensagem.desc())
+            .all()
+        )
+
+        # Para cada parceiro, a primeira linha encontrada é a última mensagem
+        # (porque a query veio ordenada de forma decrescente).
+        ultimas: dict[str, object] = {}
+        for linha in linhas:
+            parceiro = (
+                linha.destinatario
+                if linha.remetente == usuario_atual
+                else linha.remetente
+            )
+            if parceiro == usuario_atual:
+                continue
+            if parceiro not in ultimas:
+                ultimas[parceiro] = linha
+
+        if not ultimas:
+            return []
+
+        # Busca o 'nome' de exibição de cada parceiro.
+        pessoas = {
+            p.usuario: p
+            for p in self.db.query(UserModel)
+            .filter(UserModel.usuario.in_(list(ultimas.keys())))
+            .all()
+        }
+
+        itens: list[dict] = []
+        for parceiro, linha in ultimas.items():
+            pessoa = pessoas.get(parceiro)
+            nome = pessoa.nome if pessoa and pessoa.nome else parceiro
+
+            if prefixo and not (
+                parceiro.lower().startswith(prefixo)
+                or nome.lower().startswith(prefixo)
+            ):
+                continue
+
+            itens.append(
+                {
+                    "ordem": linha.id_mensagem,
+                    "item": {
+                        "tipo": "usuario",
+                        "id": parceiro,
+                        "nome": nome,
+                        "status": True,
+                        "last_message": {
+                            "remetente": linha.remetente,
+                            "texto": linha.texto,
+                        },
+                    },
+                }
+            )
+        return itens
+
+    def _conversas_de_grupo(self, usuario_atual: str, prefixo: str) -> list[dict]:
+        grupos = (
+            self.db.query(GrupoModel)
+            .join(EstaModel, EstaModel.id_grupo == GrupoModel.id_grupo)
+            .filter(EstaModel.usuario == usuario_atual)
+            .all()
+        )
+
+        itens: list[dict] = []
+        for grupo in grupos:
+            nome = grupo.nome_grupo or ""
+            if prefixo and not nome.lower().startswith(prefixo):
+                continue
+
+            # Última mensagem do grupo (pode não existir — envio de grupo ainda
+            # não é implementado no motor de chat).
+            ultima = (
+                self.db.query(MensagemModel)
+                .filter(MensagemModel.id_grupo == grupo.id_grupo)
+                .order_by(MensagemModel.id_mensagem.desc())
+                .first()
+            )
+            last_message = (
+                {"remetente": ultima.usuario, "texto": ultima.texto}
+                if ultima
+                else None
+            )
+
+            itens.append(
+                {
+                    "ordem": ultima.id_mensagem if ultima else -1,
+                    "item": {
+                        "tipo": "grupo",
+                        "id": grupo.id_grupo,
+                        "nome": grupo.nome_grupo,
+                        "status": True,
+                        "last_message": last_message,
+                    },
+                }
+            )
+        return itens
+
+    # ── Usuários ainda sem conversa (status=False) ─────────────────────────
+
+    def _usuarios_sem_conversa(
+        self,
+        usuario_atual: str,
+        termo: str,
+        ja_listados: set[str],
+    ) -> list[dict]:
+        padrao = self._escapar_like(termo) + "%"
+
+        consulta = (
+            self.db.query(UserModel)
+            .filter(UserModel.usuario != usuario_atual)
+            .filter(
+                or_(
+                    UserModel.usuario.ilike(padrao, escape="\\"),
+                    UserModel.nome.ilike(padrao, escape="\\"),
+                )
+            )
+        )
+
+        itens: list[dict] = []
+        for pessoa in consulta.all():
+            if pessoa.usuario in ja_listados:
+                continue
+            itens.append(
+                {
+                    "tipo": "usuario",
+                    "id": pessoa.usuario,
+                    "nome": pessoa.nome or pessoa.usuario,
+                    "status": False,
+                    "last_message": None,
+                }
+            )
+        return itens

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import Base, engine
-from app.routers import auth_router, chat_router, user_router
+from app.routers import auth_router, chat_router, conversas_router, user_router
 
 Base.metadata.create_all(bind=engine)
 
@@ -23,6 +23,7 @@ app.add_middleware(
 app.include_router(auth_router.router)
 app.include_router(chat_router.router)
 app.include_router(user_router.router)
+app.include_router(conversas_router.router)
 
 @app.get("/health", tags=["Status"])
 def health_check():

--- a/server/tests/step_definitions/test_edicao_exclusao_mensagens.py
+++ b/server/tests/step_definitions/test_edicao_exclusao_mensagens.py
@@ -11,27 +11,27 @@ from main import app
 # MAPEAMENTO DOS CENÁRIOS
 # ==========================================
 
-@scenario(r'C:\Users\nicol\chat-app\features\Edicao_Mensagens.feature', 'Edição de mensagem própria')
+@scenario('Edicao_Mensagens.feature', 'Edição de mensagem própria')
 def test_edicao_mensagem_propria():
     pass
 
 
-@scenario(r'C:\Users\nicol\chat-app\features\Edicao_Mensagens.feature', 'Tentativa de editar mensagem de outro usuário')
+@scenario('Edicao_Mensagens.feature', 'Tentativa de editar mensagem de outro usuário')
 def test_tentativa_editar_mensagem_de_outro_usuario():
     pass
 
 
-@scenario(r'C:\Users\nicol\chat-app\features\Exclusao_de_Mensagem.feature', 'Exclusão de mensagem própria')
+@scenario('Exclusao_de_Mensagem.feature', 'Exclusão de mensagem própria')
 def test_exclusao_mensagem_propria():
     pass
 
 
-@scenario(r'C:\Users\nicol\chat-app\features\Exclusao_de_Mensagem.feature', 'Tentativa de excluir mensagem de outro usuário')
+@scenario('Exclusao_de_Mensagem.feature', 'Tentativa de excluir mensagem de outro usuário')
 def test_tentativa_excluir_mensagem_de_outro_usuario():
     pass
 
 
-@scenario(r'C:\Users\nicol\chat-app\features\Exclusao_de_Mensagem.feature', 'Atualização da conversa após exclusão de mensagem')
+@scenario('Exclusao_de_Mensagem.feature', 'Atualização da conversa após exclusão de mensagem')
 def test_atualizacao_conversa_apos_exclusao():
     pass
 

--- a/server/tests/test_conversas.py
+++ b/server/tests/test_conversas.py
@@ -1,0 +1,223 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Feature: Lista de Conversas e Busca
+# ══════════════════════════════════════════════════════════════════════════════
+"""
+Testes do serviço/rota de busca de conversas (GET /conversas/buscar).
+
+O usuário é sempre identificado pelo JWT (header Authorization: Bearer),
+nunca por parâmetro — por isso cada teste registra e faz login para obter
+um token real.
+
+As mensagens são semeadas direto no banco de teste (mensagem + recebe),
+reproduzindo o que o motor de WebSocket grava, sem depender dele.
+"""
+from app import database
+from app.models.esta_em import EstaModel
+from app.models.grupo import GrupoModel
+from app.models.mensagem import MensagemModel
+from app.models.recebe import RecebeModel
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _registrar(client, usuario, email, telefone):
+    return client.post(
+        "/auth/register",
+        json={"usuario": usuario, "email": email, "telefone": telefone, "senha": "123456"},
+    )
+
+
+def _logar(client, email):
+    resposta = client.post("/auth/login", json={"email": email, "senha": "123456"})
+    token = resposta.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _enviar_mensagem(remetente, destinatario, texto):
+    """Grava uma mensagem 1:1 (tabelas 'mensagem' + 'recebe') no banco de teste."""
+    db = database.SessionLocal()
+    try:
+        msg = MensagemModel(
+            timestamp="2026-01-01 00:00:00",
+            texto=texto,
+            status_envio="ENVIADO",
+            usuario=remetente,
+            id_grupo=None,
+        )
+        db.add(msg)
+        db.commit()
+        db.refresh(msg)
+        db.add(RecebeModel(usuario=destinatario, id_mensagem=msg.id_mensagem, lida=0))
+        db.commit()
+        return msg.id_mensagem
+    finally:
+        db.close()
+
+
+def _criar_grupo(nome, membro):
+    """Cria um grupo e adiciona um membro (tabelas 'grupo' + 'esta_em')."""
+    db = database.SessionLocal()
+    try:
+        grupo = GrupoModel(nome_grupo=nome, data_criacao="2026-01-01", descricao=None)
+        db.add(grupo)
+        db.commit()
+        db.refresh(grupo)
+        db.add(EstaModel(usuario=membro, id_grupo=grupo.id_grupo, papel="membro", data_entrada="2026-01-01"))
+        db.commit()
+        return grupo.id_grupo
+    finally:
+        db.close()
+
+
+# ── Testes ────────────────────────────────────────────────────────────────────
+
+class TestBuscaDeConversas:
+
+    def test_busca_sem_token_retorna_401(self, client):
+        """
+        Scenario: Acesso sem autenticação é negado
+        ─────────────────────────────────────────────────
+        Given um cliente sem token JWT
+        When ele chama GET /conversas/buscar
+        Then o sistema retorna 401 (protege contra IDOR)
+        """
+        resposta = client.get("/conversas/buscar")
+
+        assert resposta.status_code == 401
+
+    def test_q_vazio_retorna_conversas_existentes_ordenadas(self, client):
+        """
+        Scenario: q vazio lista as conversas existentes, mais recentes primeiro
+        ─────────────────────────────────────────────────
+        Given "paulo" conversou com "joao" e depois com "paula"
+        When ele busca com q vazio
+        Then retorna as duas conversas, com "paula" (mais recente) primeiro
+        And cada item tem status True e a última mensagem
+        """
+        _registrar(client, "paulo", "paulo@email.com", "81900000001")
+        _registrar(client, "joao", "joao@email.com", "81900000002")
+        _registrar(client, "paula", "paula@email.com", "81900000003")
+
+        _enviar_mensagem("paulo", "joao", "fala joao")       # mais antiga
+        _enviar_mensagem("paula", "paulo", "oi paulo")       # mais recente
+
+        cabecalho = _logar(client, "paulo@email.com")
+        resposta = client.get("/conversas/buscar", headers=cabecalho)
+
+        assert resposta.status_code == 200
+        dados = resposta.json()
+
+        assert [d["id"] for d in dados] == ["paula", "joao"]   # ordenado por recência
+        assert all(d["status"] is True for d in dados)
+        assert dados[0]["tipo"] == "usuario"
+        assert dados[0]["last_message"] == {"remetente": "paula", "texto": "oi paulo"}
+
+    def test_busca_por_prefixo_case_insensitive(self, client):
+        """
+        Scenario: Busca por prefixo, ignorando maiúsculas/minúsculas
+        ─────────────────────────────────────────────────
+        Given existem os usuários "paula" e "joao"
+        When "paulo" busca por "PA"
+        Then apenas nomes que começam com "pa" são retornados (paula), não "joao"
+        """
+        _registrar(client, "paulo", "paulo@email.com", "81900000001")
+        _registrar(client, "paula", "paula@email.com", "81900000003")
+        _registrar(client, "joao", "joao@email.com", "81900000002")
+
+        cabecalho = _logar(client, "paulo@email.com")
+        resposta = client.get("/conversas/buscar?q=PA", headers=cabecalho)
+
+        assert resposta.status_code == 200
+        ids = [d["id"] for d in resposta.json()]
+
+        assert "paula" in ids
+        assert "joao" not in ids
+        assert "paulo" not in ids  # nunca retorna o próprio usuário
+
+    def test_usuario_sem_conversa_aparece_com_status_false(self, client):
+        """
+        Scenario: Usuário encontrado sem conversa iniciada vem como "conversa vazia"
+        ─────────────────────────────────────────────────
+        Given existe "carla", com quem "paulo" nunca conversou
+        When "paulo" busca por "ca"
+        Then "carla" é retornada com status False e sem última mensagem
+        """
+        _registrar(client, "paulo", "paulo@email.com", "81900000001")
+        _registrar(client, "carla", "carla@email.com", "81900000004")
+
+        cabecalho = _logar(client, "paulo@email.com")
+        resposta = client.get("/conversas/buscar?q=ca", headers=cabecalho)
+
+        assert resposta.status_code == 200
+        dados = resposta.json()
+
+        carla = next(d for d in dados if d["id"] == "carla")
+        assert carla["status"] is False
+        assert carla["last_message"] is None
+
+    def test_conversa_existente_vem_antes_de_usuario_novo(self, client):
+        """
+        Scenario: Conversas existentes têm prioridade sobre usuários novos
+        ─────────────────────────────────────────────────
+        Given "paulo" já conversou com "paula", mas nunca com "pamela"
+        When "paulo" busca por "pa"
+        Then "paula" (existente) aparece antes de "pamela" (status False)
+        """
+        _registrar(client, "paulo", "paulo@email.com", "81900000001")
+        _registrar(client, "paula", "paula@email.com", "81900000003")
+        _registrar(client, "pamela", "pamela@email.com", "81900000005")
+
+        _enviar_mensagem("paulo", "paula", "oi paula")
+
+        cabecalho = _logar(client, "paulo@email.com")
+        resposta = client.get("/conversas/buscar?q=pa", headers=cabecalho)
+
+        dados = resposta.json()
+        por_id = {d["id"]: d for d in dados}
+
+        assert por_id["paula"]["status"] is True
+        assert por_id["pamela"]["status"] is False
+        assert dados.index(por_id["paula"]) < dados.index(por_id["pamela"])
+
+    def test_isolamento_entre_usuarios_previne_idor(self, client):
+        """
+        Scenario: Um usuário não enxerga as conversas de outro
+        ─────────────────────────────────────────────────
+        Given "paulo" e "paula" trocaram mensagens
+        And "joao" não tem nenhuma conversa
+        When "joao" (autenticado) busca com q vazio
+        Then ele recebe uma lista vazia — não vê a conversa de "paulo"
+        """
+        _registrar(client, "paulo", "paulo@email.com", "81900000001")
+        _registrar(client, "paula", "paula@email.com", "81900000003")
+        _registrar(client, "joao", "joao@email.com", "81900000002")
+
+        _enviar_mensagem("paulo", "paula", "segredo")
+
+        cabecalho = _logar(client, "joao@email.com")
+        resposta = client.get("/conversas/buscar", headers=cabecalho)
+
+        assert resposta.status_code == 200
+        assert resposta.json() == []
+
+    def test_grupo_que_participo_aparece_na_lista(self, client):
+        """
+        Scenario: Grupos dos quais o usuário participa entram na lista
+        ─────────────────────────────────────────────────
+        Given "paulo" participa do grupo "Paladinos"
+        When ele busca com q vazio
+        Then o grupo aparece com tipo "grupo", status True e sem última mensagem
+        """
+        _registrar(client, "paulo", "paulo@email.com", "81900000001")
+        id_grupo = _criar_grupo("Paladinos", "paulo")
+
+        cabecalho = _logar(client, "paulo@email.com")
+        resposta = client.get("/conversas/buscar", headers=cabecalho)
+
+        dados = resposta.json()
+        grupo = next(d for d in dados if d["tipo"] == "grupo")
+
+        assert grupo["id"] == id_grupo
+        assert grupo["nome"] == "Paladinos"
+        assert grupo["status"] is True
+        assert grupo["last_message"] is None


### PR DESCRIPTION
Criação da Rota de busca das conversas do usuário autenticado via JWT (Bearer) Busca por prefixo case-insensitive sobre conversas 1:1 e grupos do usuário, conversas existentes primeiro, usuários sem conversa vão aparecer como status=False

  - server/app/core/security.py (novo) — valida e decodifica o JWT
  - server/app/services/conversas_service.py (novo) — derivação e busca
  - server/app/routers/conversas_router.py (novo) — a rota
  - server/tests/test_conversas.py (novo) — 7 casos
  - features/lista_conversas.feature (novo) — cenários BDD
  - server/main.py — registro aditivo do router (2 linhas)
  - server/tests/step_definitions/test_edicao_exclusao_mensagens.py — fix de caminho absoluto do Windows para relativo

Fix: caminho absoluto do Windows para relativo em test_edicao_exclusao_mensagens

## Testes
 -7 casos novos cobrindo auth/401, busca por prefixo, ordenação, status false, prioridade de existentes, isolamento entre usuários (IDOR) e grupos. Suíte total: 62 passando.

 ## Notas
 - Frontend ainda não envia o header Authorization — ao integrar, precisará mandar o access_token do login